### PR TITLE
Internationalizing pages, fragments, layouts in the foundation component

### DIFF
--- a/components/org.wso2.carbon.uuf.common.foundation.ui/src/main/fragments/menubar/menubar.hbs
+++ b/components/org.wso2.carbon.uuf.common.foundation.ui/src/main/fragments/menubar/menubar.hbs
@@ -2,32 +2,31 @@
     {{~#menu "main"}}
         {{~#if @leaf}}
             <li>
-                <a href="{{@contextPath}}{{link}}">{{#if icon}}<i class="{{icon}}"></i>{{/if}}{{text}}</a>
+                <a href="{{@contextPath}}{{link}}">{{#if icon}}<i class="{{icon}}"></i>{{/if}}{{i18n text}}</a>
             </li>
         {{~else}}
             <li class="dropdown">
                 <a href="{{#if link}}{{@contextPath}}{{link}}{{else}}#{{/if}}"
                    class="dropdown-toggle" data-toggle="dropdown"
                    role="button" aria-haspopup="true" aria-expanded="false">
-                    {{#if icon}}<i class="{{icon}}"></i>{{/if}}{{text~}}
-                    <span class="caret"></span>
+                    {{#if icon}}<i class="{{icon}}"></i>{{/if}}{{i18n text}}<span class="caret"></span>
                 </a>
                 <ul class="dropdown-menu">
                     {{~#menu subMenus}}
                         {{~#if @leaf}}
                             <li>
                                 <a href="{{@contextPath}}{{link}}">
-                                    {{#if icon}}<i class="{{icon}}"></i>{{/if}}{{text}}
+                                    {{#if icon}}<i class="{{icon}}"></i>{{/if}}{{i18n text}}
                                 </a>
                             </li>
                         {{~else}}
                             <li class="dropdown-submenu">
-                                <a href="{{#if link}}{{@contextPath}}{{link}}{{else}}#{{/if}}">{{text}}</a>
+                                <a href="{{#if link}}{{@contextPath}}{{link}}{{else}}#{{/if}}">{{i18n text}}</a>
                                 <ul class="dropdown-menu">
                                     {{#menu subMenus}}
                                         <li>
                                             <a href="{{@contextPath}}{{link}}">
-                                                {{#if icon}}<i class="{{icon}}"></i>{{/if}}{{text}}
+                                                {{#if icon}}<i class="{{icon}}"></i>{{/if}}{{i18n text}}
                                             </a>
                                         </li>
                                     {{/menu}}

--- a/components/org.wso2.carbon.uuf.common.foundation.ui/src/main/fragments/secured-menubar/secured-menubar.hbs
+++ b/components/org.wso2.carbon.uuf.common.foundation.ui/src/main/fragments/secured-menubar/secured-menubar.hbs
@@ -1,2 +1,2 @@
-{{secured}}
-{{fragment "menubar"}}
+{{secured~}}
+{{fragment "menubar"~}}

--- a/components/org.wso2.carbon.uuf.common.foundation.ui/src/main/lang/en-US.properties
+++ b/components/org.wso2.carbon.uuf.common.foundation.ui/src/main/lang/en-US.properties
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+## App
+app.name=UUF Foundation
+
+## UUF Foundation
+# UUF Foundation - 404 error page
+foundation.page.404.title=Page Not Found
+foundation.page.404.heading=Page Not Found!
+# UUF Foundation - default error page
+foundation.page.default.title=Error
+foundation.page.default.heading=An Error Occurred!
+foundation.page.default.http-status=HTTP Status

--- a/components/org.wso2.carbon.uuf.common.foundation.ui/src/main/layouts/main.hbs
+++ b/components/org.wso2.carbon.uuf.common.foundation.ui/src/main/layouts/main.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -7,7 +7,7 @@
     {{#placeholder "favicon"}}
         <link rel="shortcut icon" href="{{public "images/default-favicon.png"}}" type="image/png" />
     {{/placeholder}}
-    <title>{{#placeholder "title"}}UUF Foundation{{/placeholder}}</title>
+    <title>{{#placeholder "title"}}{{i18n "app.name"}}{{/placeholder}}</title>
     {{placeholder "css"}}
     {{placeholder "headJs"}}
     {{placeholder "headOther"}}

--- a/components/org.wso2.carbon.uuf.common.foundation.ui/src/main/pages/error/404.hbs
+++ b/components/org.wso2.carbon.uuf.common.foundation.ui/src/main/pages/error/404.hbs
@@ -1,8 +1,9 @@
 {{layout "main"}}
-{{title "Page Not Found | " @config.appName}}
+{{title (i18n "foundation.page.404.title") " | " (i18n "app.name")}}
+
 {{#fillZone "content"}}
     <div class="message message-danger">
-        <h4><i class="icon fw fw-error"></i>Page Not Found!</h4>
+        <h4><i class="icon fw fw-error"></i>{{i18n "foundation.page.404.heading"}}</h4>
 
         <div style="padding-left: 25px;">
             <p style="white-space: pre-wrap;">{{@params.message}}</p>

--- a/components/org.wso2.carbon.uuf.common.foundation.ui/src/main/pages/error/default.hbs
+++ b/components/org.wso2.carbon.uuf.common.foundation.ui/src/main/pages/error/default.hbs
@@ -1,11 +1,12 @@
 {{layout "main"}}
-{{title "Error | " @config.appName}}
+{{title (i18n "foundation.page.default.title") " | " (i18n "app.name")}}
+
 {{#fillZone "content"}}
     <div class="message message-danger">
-        <h4><i class="icon fw fw-error"></i>An Error Occurred!</h4>
+        <h4><i class="icon fw fw-error"></i>{{i18n "foundation.page.default.heading"}}</h4>
 
         <div style="padding-left: 25px;">
-            <h5><b>HTTP Status : {{@params.status}}</b></h5>
+            <h5><b>{{i18n "foundation.page.default.http-status"}}  : {{@params.status}}</b></h5>
 
             <p style="white-space: pre-wrap;">{{@params.message}}</p>
         </div>


### PR DESCRIPTION
Fixes #34.

Following in the `org.wso2.carbon.uuf.common.foundation.ui` component are internationalized in this PR.
- 404 error page
- default error page
- main layout
- menubar fragment
- secured-menubar fragment