### PR TITLE
Add i18n function signature to UUFClient

### DIFF
--- a/components/org.wso2.carbon.uuf.common.foundation.ui/src/main/fragments/uuf-client/public/uuf-client/uuf-client.js
+++ b/components/org.wso2.carbon.uuf.common.foundation.ui/src/main/fragments/uuf-client/public/uuf-client/uuf-client.js
@@ -438,6 +438,11 @@ var UUFClient = {};
             }
         };
 
+    /**
+     * Returns the i18n message for the given key.
+     * @param messageKey message key
+     * @returns i18n message
+     */
     UUFClient.i18n = function (messageKey) {
         // TODO: 5/4/17 implement i18n capability to UUFClient, until we just return the messageKey.
         return messageKey;

--- a/components/org.wso2.carbon.uuf.common.foundation.ui/src/main/fragments/uuf-client/public/uuf-client/uuf-client.js
+++ b/components/org.wso2.carbon.uuf.common.foundation.ui/src/main/fragments/uuf-client/public/uuf-client/uuf-client.js
@@ -438,4 +438,9 @@ var UUFClient = {};
             }
         };
 
+    UUFClient.i18n = function (messageKey) {
+        // TODO: 5/4/17 implement i18n capability to UUFClient, until we just return the messageKey.
+        return messageKey;
+    };
+
 })(UUFClient);


### PR DESCRIPTION
This PR adds the `UUFClient.i18n()` function signature to `UUFClient`. 